### PR TITLE
Remove unnecessary regexp from dynamic publicPath assignment

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -27,15 +27,8 @@ const start = async () => {
     clientConfig.output.hotUpdateMainFilename = 'updates/[hash].hot-update.json';
     clientConfig.output.hotUpdateChunkFilename = 'updates/[id].[hash].hot-update.js';
 
-    const publicPath = clientConfig.output.publicPath;
-
-    clientConfig.output.publicPath = [`http://localhost:${WEBPACK_PORT}`, publicPath]
-        .join('/')
-        .replace(/([^:+])\/+/g, '$1/');
-
-    serverConfig.output.publicPath = [`http://localhost:${WEBPACK_PORT}`, publicPath]
-        .join('/')
-        .replace(/([^:+])\/+/g, '$1/');
+    clientConfig.output.publicPath = `http://localhost:${WEBPACK_PORT}${paths.publicPath}`;
+    serverConfig.output.publicPath = `http://localhost:${WEBPACK_PORT}${paths.publicPath}`;
 
     const multiCompiler = webpack([clientConfig, serverConfig]);
 


### PR DESCRIPTION
Is there something where that regexp can be required? I checked and it seems to be unnecessary. Maybe there is something you remember.