### PR TITLE
chores(depcruise): check ts pre compilation dependencies

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -114,7 +114,7 @@ module.exports = {
         // , prefix: ''
 
         /* if true detect dependencies that only exist before typescript-to-javascript compilation */
-        // , tsPreCompilationDeps: false
+        tsPreCompilationDeps: true,
 
         /* if true combines the package.jsons found from the module up to the base
            folder the cruise is initiated from. Useful for how (some) mono-repos

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "analyze": "yarn-or-npm build:with-stats && yarn-or-npm start:analyzer",
     "build": "cross-env NODE_ENV=production node scripts/build.js",
     "build:with-stats": "cross-env NODE_ENV=production webpack --config config/webpack.config.js/client.prod.js --json > build/client/static/bundle-stats.json",
-    "depgraph": "depcruise --exclude '^node_modules' --output-type dot src | dot -T svg > dependency-graph.svg",
+    "depgraph": "depcruise -c .dependency-cruiser.js --exclude '^node_modules' --output-type dot src | dot -T svg > dependency-graph.svg",
     "link-react": "yarn-or-npm link react react-dom",
     "lint": "concurrently \"yarn-or-npm lint:js\" \"yarn-or-npm lint:css\"",
     "lint:js": "eslint src/**/*.{js,jsx,ts,tsx}",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "concurrently \"yarn-or-npm lint:js\" \"yarn-or-npm lint:css\"",
     "lint:js": "eslint src/**/*.{js,jsx,ts,tsx}",
     "lint:css": "stylelint src/**/*.css",
-    "lint:deps": "depcruise -c .dependency-cruiser.js --ts-config tsconfig.json src/",
+    "lint:deps": "depcruise -c .dependency-cruiser.js src/",
     "plop": "plop",
     "start": "cross-env NODE_ENV=development node scripts/start.js",
     "start:analyzer": "webpack-bundle-analyzer build/client/static/bundle-stats.json",


### PR DESCRIPTION
## Description / What does this PR do?
- Configure the `lint:deps` run script so it also takes typescript dependencies into account that exist before compilation.
- Do the same for the `depgraph` script by passing it the dependency-cruiser config
- Removes the --ts-config parameter from the run-script in package.json, as it's already configured in .dependency-cruiser.js 
(Command line parameters override options in the config - so if you'd change the reference to the tsconfig there (which might happen, given the nature of this repo), it would have no effect.)

## Related Issue / Story / Ticket
https://github.com/sverweij/dependency-cruiser/issues/127
