### PR TITLE
Fix history for SSR routes (resolves #48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.0-beta.1 (2019-05-03)
+
+-   Fix #48. Create a single history for the store and pass initial request so SSR works for routes
+
 ## 3.0.0-beta.0 (2019-05-02)
 
 -   Dropped Flow Type in favor of TypeScript (sorry Flow, but the battle is lost)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ssr-setup",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "author": "Manuel Bieh <npm@manuelbieh.de> (https://github.com/manuelbieh)",
   "license": "MIT",
   "engines": {

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -1,24 +1,26 @@
 import React from 'react';
 import { hydrate } from 'react-dom';
 import { Provider } from 'react-redux';
-import { ConnectedRouter as Router, routerMiddleware } from 'connected-react-router';
+import { ConnectedRouter as Router } from 'connected-react-router';
 import { configureStore } from '../shared/store';
 import App from '../shared/App';
 import IntlProvider from '../shared/i18n/IntlProvider';
 import createHistory from '../shared/store/history';
 
-const browserHistory = createHistory();
+const history = createHistory();
 
+// Create/use the store
+// history MUST be passed here if you want syncing between server on initial route
 const store =
     window.store ||
     configureStore({
         initialState: window.__PRELOADED_STATE__,
-        middleware: [routerMiddleware(browserHistory)],
+        history,
     });
 
 hydrate(
     <Provider store={store}>
-        <Router history={browserHistory}>
+        <Router history={history}>
             <IntlProvider>
                 <App />
             </IntlProvider>

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -9,6 +9,7 @@ import { configureStore } from '../shared/store';
 import paths from '../../config/paths';
 import errorHandler from './middleware/errorHandler';
 import serverRenderer from './middleware/serverRenderer';
+import createHistory from '../shared/store/history';
 
 require('dotenv').config();
 
@@ -31,11 +32,12 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 
 const addStore = (
-    _req: express.Request,
+    req: express.Request,
     res: express.Response,
     next: express.NextFunction | undefined
 ): void => {
-    res.locals.store = configureStore();
+    const history = createHistory({ initialEntries: [req.url] });
+    res.locals.store = configureStore({ history });
     if (typeof next !== 'function') {
         throw new Error('Next handler is missing');
     }

--- a/src/shared/store/history.ts
+++ b/src/shared/store/history.ts
@@ -1,14 +1,18 @@
 import { createMemoryHistory, createBrowserHistory } from 'history';
 
-export const createUniversalHistory = () => {
+type HistoryParams = {
+    initialEntries?: any[];
+};
+
+export const createUniversalHistory = ({ initialEntries = [] }: HistoryParams = {}) => {
     if (__BROWSER__) {
-        const history = window.browserHistory || createBrowserHistory();
+        const history = window.browserHistory || createBrowserHistory({ initialEntries });
         if (process.env.NODE_ENV === 'development' && !window.browserHistory) {
             window.browserHistory = history;
         }
         return history;
     }
-    return createMemoryHistory();
+    return createMemoryHistory({ initialEntries });
 };
 
 export default createUniversalHistory;

--- a/src/shared/store/index.ts
+++ b/src/shared/store/index.ts
@@ -1,13 +1,15 @@
 import thunk from 'redux-thunk';
 import { createStore, applyMiddleware, compose } from 'redux';
-import rootReducer from './rootReducer';
+import createRootReducer from './rootReducer';
+import { routerMiddleware } from 'connected-react-router';
 
 type StoreParams = {
+    history: any[];
     initialState?: { [key: string]: any };
     middleware?: any[];
 };
 
-export const configureStore = ({ initialState, middleware = [] }: StoreParams = {}) => {
+export const configureStore = ({ history, initialState, middleware = [] }: StoreParams) => {
     const devtools =
         typeof window !== 'undefined' &&
         typeof window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ === 'function' &&
@@ -16,9 +18,11 @@ export const configureStore = ({ initialState, middleware = [] }: StoreParams = 
     const composeEnhancers = devtools || compose;
 
     const store = createStore(
-        rootReducer,
+        createRootReducer(history),
         initialState,
-        composeEnhancers(applyMiddleware(...[thunk].concat(...middleware)))
+        composeEnhancers(
+            applyMiddleware(...[thunk, routerMiddleware(history)].concat(...middleware))
+        )
     );
 
     if (process.env.NODE_ENV !== 'production') {

--- a/src/shared/store/rootReducer.ts
+++ b/src/shared/store/rootReducer.ts
@@ -1,13 +1,11 @@
 import { combineReducers } from 'redux';
 import { connectRouter } from 'connected-react-router';
-import createHistory from './history';
 import app from './app/reducer';
 
-const history = createHistory();
+const createRootReducer = (history) =>
+    combineReducers({
+        app,
+        router: connectRouter(history),
+    });
 
-const rootReducer = combineReducers({
-    app,
-    router: connectRouter(history),
-});
-
-export default rootReducer;
+export default createRootReducer;


### PR DESCRIPTION
<!-- Please remove any sections which are unaffected or not applicable. -->
## Summary
This resolves #48 - sorry it took me a bit. 😅

The issue was twofold. 

Firstly, the histories created in `client/index.tsx` and `rootReducer.ts` are different objects. This means that the `<Router>` on the client and the `routerMiddelware` were getting one history while `rootReducer` was getting a different one and they couldn't sync. (Partially covered [here](https://github.com/supasate/connected-react-router/blob/master/FAQ.md#how-to-migrate-from-v4-to-v5v6))

This is fixed by creating one a single history and passing it in to the store. There the store will create the necessary middleware and create a root reducer using that singular value history.

Secondly, the app would load `/` on every SSR since it wasn't provided with an initial history entry. This is fixed by providing `{ initialEntries: [req.url] }` when creating the history for the server.

### Caveats
I'm not a TypeScript guy. Would be worth checking to see that the types are to your liking.

## Issue
Fixes #48

## Changelog
-   Fix #48. Create a single history for the store and pass initial request so SSR works for routes
