### PR TITLE
modify module history v5.0.0 to v4.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "express": "^4.16.4",
     "express-manifest-helpers": "^0.6.0",
     "glob": "^7.1.6",
-    "history": "^5.0.0",
+    "history": "^4.10.1",
     "i18next": "^19.4.4",
     "i18next-xhr-backend": "^3.2.2",
     "immer": "^7.0.5",


### PR DESCRIPTION
I have recently upgraded this code and notice that `history.push()` and `Link` stopped working.
Its look like there is some issue in the newest version "5.0.0" of history package.
For now we can change its version to "4.10.1" which works for me.