### PR TITLE
fix vendor CSS not generating in production mode

### DIFF
--- a/config/webpack.config.ts/loaders.ts
+++ b/config/webpack.config.ts/loaders.ts
@@ -56,6 +56,11 @@ const cssModuleLoaderClient = {
             },
         },
     ],
+    // Don't consider CSS imports dead code even if the
+    // containing package claims to have no side effects.
+    // Remove this when webpack adds a warning or an error for this.
+    // See https://github.com/webpack/webpack/issues/6571
+    sideEffects: true,
 };
 
 const cssLoaderClient = {
@@ -72,6 +77,11 @@ const cssLoaderClient = {
             },
         },
     ],
+    // Don't consider CSS imports dead code even if the
+    // containing package claims to have no side effects.
+    // Remove this when webpack adds a warning or an error for this.
+    // See https://github.com/webpack/webpack/issues/6571
+    sideEffects: true,
 };
 
 const cssModuleLoaderServer = {
@@ -93,12 +103,22 @@ const cssModuleLoaderServer = {
             },
         },
     ],
+    // Don't consider CSS imports dead code even if the
+    // containing package claims to have no side effects.
+    // Remove this when webpack adds a warning or an error for this.
+    // See https://github.com/webpack/webpack/issues/6571
+    sideEffects: true,
 };
 
 const cssLoaderServer = {
     test: cssRegex,
     exclude: cssModuleRegex,
     use: [MiniCssExtractPlugin.loader, require.resolve('css-loader')],
+    // Don't consider CSS imports dead code even if the
+    // containing package claims to have no side effects.
+    // Remove this when webpack adds a warning or an error for this.
+    // See https://github.com/webpack/webpack/issues/6571
+    sideEffects: true,
 };
 
 const urlLoaderClient = {


### PR DESCRIPTION
## Description / What does this PR do?

Given importing CSS from a vendor in `node_modules`
and the `package.json` in that package sets `sideEffects: false` 
When importing the vendor CSS in the app 
CSS does not generate in production build 

Fix is similar to what `create-react-app` is doing.

## Related Issue / Story / Ticket

Fixes https://github.com/manuelbieh/react-ssr-setup/issues/140

## Changelog

Add nuclear option of setting `sideEffects: true` for any CSS, since CSS by its nature is side-effecty and should not be tree shaken. 

## Checklist

*   [x] Tests