### PR TITLE
Speed up watch mode tests

### DIFF
--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -20,6 +20,8 @@ const argv = process.argv.slice(2);
 // Watch unless on CI or in coverage mode
 if (!process.env.CI && argv.includes('--coverage') === false) {
     argv.push('--watch');
+    // Speed up watch mode tests according to https://ivantanev.com/make-jest-faster/
+    argv.push('--maxWorkers=25%');
 }
 
 jest.run(argv);


### PR DESCRIPTION
... according to https://ivantanev.com/make-jest-faster/

I used this option in my own project and the test time gets reduced from 4s to 1.5s，I think it is worth applying.


## What does this PR do?

This PR can reduce Jest test time.